### PR TITLE
[codex] refine roster ping compact mode

### DIFF
--- a/scripts/commands/roster_command.ts
+++ b/scripts/commands/roster_command.ts
@@ -800,6 +800,12 @@ export const ROSTER_COMMAND: RESTPostAPIApplicationCommandsJSONBody = {
           type: ApplicationCommandOptionType.String
         },
         {
+          name: 'compact',
+          description: command.roster.ping.options.compact.description,
+          description_localizations: translation('command.roster.ping.options.compact.description'),
+          type: ApplicationCommandOptionType.Boolean
+        },
+        {
           name: 'ping_option',
           description: command.roster.ping.options.ping_option.description,
           description_localizations: translation(

--- a/src/commands/rosters/roster-ping.ts
+++ b/src/commands/rosters/roster-ping.ts
@@ -25,6 +25,7 @@ export default class RosterPingCommand extends Command {
       ping_option?: 'unregistered' | 'missing' | 'everyone';
       group?: string;
       message?: string;
+      compact?: boolean;
     }
   ) {
     if (!(args.ping_option || args.group))
@@ -54,8 +55,10 @@ export default class RosterPingCommand extends Command {
 
     // close all rosters that should be closed
     this.client.rosterManager.closeRosters(interaction.guild.id);
+    const compact = args.compact === true;
 
-    const msgText = `\u200e**${roster.name} - ${roster.clan.name} (${roster.clan.tag})** ${args.message ? `\n\n${args.message}` : ''}`;
+    const msgText = `\u200e**${roster.name} - ${roster.clan.name} (${roster.clan.tag})**`;
+    const header = args.message ? `${msgText}\n\n${args.message}` : msgText;
 
     if (args.group) {
       const groupMembers = updated.members.filter(
@@ -72,7 +75,7 @@ export default class RosterPingCommand extends Command {
         };
       });
 
-      return this.followUp(interaction, msgText, result);
+      return this.followUp(interaction, header, result, compact);
     }
 
     if (args.ping_option === 'unregistered') {
@@ -93,7 +96,7 @@ export default class RosterPingCommand extends Command {
           mention: `${member.userId ? `<@${member.userId}>` : ''}`
         };
       });
-      return this.followUp(interaction, msgText, result);
+      return this.followUp(interaction, header, result, compact);
     }
 
     if (args.ping_option === 'missing') {
@@ -110,8 +113,7 @@ export default class RosterPingCommand extends Command {
           mention: `${member.userId ? `<@${member.userId}>` : ''}`
         };
       });
-
-      return this.followUp(interaction, msgText, result);
+      return this.followUp(interaction, header, result, compact);
     }
 
     const result = updated.members.map((member) => {
@@ -120,13 +122,14 @@ export default class RosterPingCommand extends Command {
         mention: `${member.userId ? `<@${member.userId}>` : ''}`
       };
     });
-    return this.followUp(interaction, msgText, result);
+    return this.followUp(interaction, header, result, compact);
   }
 
   private async followUp(
     interaction: CommandInteraction<'cached'>,
-    msgText: string,
-    result: { name: string; mention: string }[]
+    header: string,
+    result: { name: string; mention: string }[],
+    compact: boolean
   ) {
     const customIds = {
       confirm: this.client.uuid(interaction.user.id)
@@ -137,9 +140,13 @@ export default class RosterPingCommand extends Command {
         .setLabel('Confirm and Ping')
         .setStyle(ButtonStyle.Primary)
     );
+    const preview = result.map((m) => `0. \u200e${m.name}`).join('\n');
+    const pingContent = compact
+      ? result.map((m) => m.mention).join('')
+      : result.map((m) => `- \u200e${m.name} ${m.mention}`).join('\n');
 
     const message = await interaction.editReply({
-      content: `${msgText}\n${result.map((m) => `0. \u200e${m.name}`).join('\n')}`,
+      content: `${header}\n\n${preview}`,
       components: interaction.ephemeral ? [] : [row],
       allowedMentions: { parse: [] }
     });
@@ -151,15 +158,12 @@ export default class RosterPingCommand extends Command {
       onClick: async (action) => {
         await action.update({
           components: [],
-          content: `${msgText}\nPinging ${result.length} members`
+          content: `${header}\n\nPinging ${result.length} members`
         });
 
-        for (const content of Util.splitMessage(
-          `${msgText}\n${result.map((m) => `- \u200e${m.name} ${m.mention}`).join('\n')}`,
-          {
-            maxLength: 2000
-          }
-        )) {
+        for (const content of Util.splitMessage(`${header}\n\n${pingContent}`, {
+          maxLength: 2000
+        })) {
           await action.followUp({ content });
         }
       }

--- a/src/util/locales.ts
+++ b/src/util/locales.ts
@@ -617,6 +617,9 @@ export const command = {
         message: {
           description: 'Message for the members'
         },
+        compact: {
+          description: 'Send member pings in a compact inline format'
+        },
         ping_option: {
           description: 'Select a ping option'
         },


### PR DESCRIPTION
## What changed

- Added a compact mode for roster ping output that is enabled only by an explicit `true` value.
- Compact mode sends the member pings inline, while the preview stays in the standard numbered format.
- Added a blank line between the roster message and the ping block for readability in both preview and send flows.
- Kept the confirmation flow and message splitting behavior unchanged.

## Example

With a message like `Please check in today` and members `@playerone`, `@playertwo`, `@playerthree`:

Preview:

```text
Roster Name - Clan Name (#CLAN)

Please check in today

0. Player One (#ABC)
0. Player Two (#DEF)
0. Player Three (#GHI)
```

Sent compact content:

```text
Roster Name - Clan Name (#CLAN)

Please check in today

@playerone@playertwo@playerthree
```

## Why

This introduces a compact output mode for roster pings so managers can choose a denser send format without changing the preview behavior.

## Validation

- eslint src/commands/rosters/roster-ping.ts
