### PR TITLE
fix(summary): handle live vs archived CWL seasons in cwl-ranks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clashperk",
-  "version": "4.2.92",
+  "version": "4.2.93",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clashperk",
-      "version": "4.2.92",
+      "version": "4.2.93",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/cerebras": "^2.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clashperk",
-  "version": "4.2.92",
+  "version": "4.2.93",
   "author": "",
   "license": "MIT",
   "description": "Clash of Clans Discord Bot",

--- a/scripts/assets/commands_export.json
+++ b/scripts/assets/commands_export.json
@@ -127,6 +127,7 @@
         "description": "The season to show attacks for.",
         "type": "String",
         "choices": [
+          "Aug 2026",
           "Jul 2026",
           "Jun 2026",
           "May 2026",
@@ -143,8 +144,7 @@
           "Jun 2025",
           "May 2025",
           "Apr 2025",
-          "Mar 2025",
-          "Feb 2025"
+          "Mar 2025"
         ]
       }
     ]
@@ -930,12 +930,12 @@
         "description": "The week to show contributions for.",
         "type": "String",
         "choices": [
-          "26 Jun, 2026",
-          "19 Jun, 2026",
-          "12 Jun, 2026",
-          "05 Jun, 2026",
-          "29 May, 2026",
-          "22 May, 2026"
+          "07 Aug, 2026",
+          "31 Jul, 2026",
+          "24 Jul, 2026",
+          "17 Jul, 2026",
+          "10 Jul, 2026",
+          "03 Jul, 2026"
         ]
       }
     ]
@@ -962,12 +962,12 @@
         "description": "Retrieve data for the specified raid weekend.",
         "type": "String",
         "choices": [
-          "26 Jun, 2026",
-          "19 Jun, 2026",
-          "12 Jun, 2026",
-          "05 Jun, 2026",
-          "29 May, 2026",
-          "22 May, 2026"
+          "07 Aug, 2026",
+          "31 Jul, 2026",
+          "24 Jul, 2026",
+          "17 Jul, 2026",
+          "10 Jul, 2026",
+          "03 Jul, 2026"
         ]
       }
     ]
@@ -1070,6 +1070,7 @@
         "description": "The season to show the scoreboard for.",
         "type": "String",
         "choices": [
+          "Aug 2026",
           "Jul 2026",
           "Jun 2026",
           "May 2026",
@@ -1086,8 +1087,7 @@
           "Jun 2025",
           "May 2025",
           "Apr 2025",
-          "Mar 2025",
-          "Feb 2025"
+          "Mar 2025"
         ]
       }
     ]
@@ -1183,6 +1183,8 @@
         "description": "CWL season",
         "type": "String",
         "choices": [
+          "Aug 2026",
+          "Jul 2026",
           "Jun 16, 2026",
           "Jun 2026",
           "May 2026",
@@ -1193,9 +1195,7 @@
           "Dec 2025",
           "Nov 2025",
           "Oct 2025",
-          "Sep 2025",
-          "Aug 2025",
-          "Jul 2025"
+          "Sep 2025"
         ]
       },
       {
@@ -1279,6 +1279,8 @@
         "description": "CWL season",
         "type": "String",
         "choices": [
+          "Aug 2026",
+          "Jul 2026",
           "Jun 16, 2026",
           "Jun 2026",
           "May 2026",
@@ -1289,9 +1291,7 @@
           "Dec 2025",
           "Nov 2025",
           "Oct 2025",
-          "Sep 2025",
-          "Aug 2025",
-          "Jul 2025"
+          "Sep 2025"
         ]
       },
       {
@@ -1318,6 +1318,8 @@
         "description": "CWL season",
         "type": "String",
         "choices": [
+          "Aug 2026",
+          "Jul 2026",
           "Jun 16, 2026",
           "Jun 2026",
           "May 2026",
@@ -1328,9 +1330,7 @@
           "Dec 2025",
           "Nov 2025",
           "Oct 2025",
-          "Sep 2025",
-          "Aug 2025",
-          "Jul 2025"
+          "Sep 2025"
         ]
       },
       {
@@ -1357,6 +1357,8 @@
         "description": "CWL season",
         "type": "String",
         "choices": [
+          "Aug 2026",
+          "Jul 2026",
           "Jun 16, 2026",
           "Jun 2026",
           "May 2026",
@@ -1367,9 +1369,7 @@
           "Dec 2025",
           "Nov 2025",
           "Oct 2025",
-          "Sep 2025",
-          "Aug 2025",
-          "Jul 2025"
+          "Sep 2025"
         ]
       },
       {
@@ -1408,6 +1408,7 @@
         "description": "The season to show donations for.",
         "type": "String",
         "choices": [
+          "Aug 2026",
           "Jul 2026",
           "Jun 2026",
           "May 2026",
@@ -1424,8 +1425,7 @@
           "Jun 2025",
           "May 2025",
           "Apr 2025",
-          "Mar 2025",
-          "Feb 2025"
+          "Mar 2025"
         ]
       },
       {
@@ -1556,6 +1556,8 @@
         "description": "Retrieve data since the specified season.",
         "type": "String",
         "choices": [
+          "Aug 2026",
+          "Jul 2026",
           "Jun 16, 2026",
           "Jun 2026",
           "May 2026",
@@ -1566,9 +1568,7 @@
           "Dec 2025",
           "Nov 2025",
           "Oct 2025",
-          "Sep 2025",
-          "Aug 2025",
-          "Jul 2025"
+          "Sep 2025"
         ]
       },
       {
@@ -1604,6 +1604,7 @@
         "description": "Retrieve data since the specified season.",
         "type": "String",
         "choices": [
+          "Aug 2026",
           "Jul 2026",
           "Jun 2026",
           "May 2026",
@@ -1620,8 +1621,7 @@
           "Jun 2025",
           "May 2025",
           "Apr 2025",
-          "Mar 2025",
-          "Feb 2025"
+          "Mar 2025"
         ]
       },
       {
@@ -1678,6 +1678,7 @@
         "description": "Retrieve data since the specified season.",
         "type": "String",
         "choices": [
+          "Since Aug 2026",
           "Since Jul 2026",
           "Since Jun 2026",
           "Since May 2026",
@@ -1694,8 +1695,7 @@
           "Since Jun 2025",
           "Since May 2025",
           "Since Apr 2025",
-          "Since Mar 2025",
-          "Since Feb 2025"
+          "Since Mar 2025"
         ]
       },
       {
@@ -1739,6 +1739,7 @@
         "description": "Retrieve data since the specified season.",
         "type": "String",
         "choices": [
+          "Aug 2026",
           "Jul 2026",
           "Jun 2026",
           "May 2026",
@@ -1755,8 +1756,7 @@
           "Jun 2025",
           "May 2025",
           "Apr 2025",
-          "Mar 2025",
-          "Feb 2025"
+          "Mar 2025"
         ]
       },
       {
@@ -2082,6 +2082,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Aug 2026",
           "Jul 2026",
           "Jun 2026",
           "May 2026",
@@ -2098,8 +2099,7 @@
           "Jun 2025",
           "May 2025",
           "Apr 2025",
-          "Mar 2025",
-          "Feb 2025"
+          "Mar 2025"
         ]
       }
     ]
@@ -2120,6 +2120,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Aug 2026",
           "Jul 2026",
           "Jun 2026",
           "May 2026",
@@ -2136,8 +2137,7 @@
           "Jun 2025",
           "May 2025",
           "Apr 2025",
-          "Mar 2025",
-          "Feb 2025"
+          "Mar 2025"
         ]
       }
     ]
@@ -2158,6 +2158,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Aug 2026",
           "Jul 2026",
           "Jun 2026",
           "May 2026",
@@ -2174,8 +2175,7 @@
           "Jun 2025",
           "May 2025",
           "Apr 2025",
-          "Mar 2025",
-          "Feb 2025"
+          "Mar 2025"
         ]
       }
     ]
@@ -2252,6 +2252,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Aug 2026",
           "Jul 2026",
           "Jun 2026",
           "May 2026",
@@ -2268,8 +2269,7 @@
           "Jun 2025",
           "May 2025",
           "Apr 2025",
-          "Mar 2025",
-          "Feb 2025"
+          "Mar 2025"
         ]
       },
       {
@@ -3278,6 +3278,12 @@
         "choices": []
       },
       {
+        "name": "compact",
+        "description": "Send member pings in a compact inline format",
+        "type": "Boolean",
+        "choices": []
+      },
+      {
         "name": "ping_option",
         "description": "Select a ping option",
         "type": "String",
@@ -3604,6 +3610,7 @@
         "description": "Retrieve data since the specified season.",
         "type": "String",
         "choices": [
+          "Since Aug 2026",
           "Since Jul 2026",
           "Since Jun 2026",
           "Since May 2026",
@@ -3620,8 +3627,7 @@
           "Since Jun 2025",
           "Since May 2025",
           "Since Apr 2025",
-          "Since Mar 2025",
-          "Since Feb 2025"
+          "Since Mar 2025"
         ]
       },
       {
@@ -3724,6 +3730,7 @@
         "description": "Retrieve data since the specified season.",
         "type": "String",
         "choices": [
+          "Since Aug 2026",
           "Since Jul 2026",
           "Since Jun 2026",
           "Since May 2026",
@@ -3740,8 +3747,7 @@
           "Since Jun 2025",
           "Since May 2025",
           "Since Apr 2025",
-          "Since Mar 2025",
-          "Since Feb 2025"
+          "Since Mar 2025"
         ]
       },
       {
@@ -3783,6 +3789,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Aug 2026",
           "Jul 2026",
           "Jun 2026",
           "May 2026",
@@ -3799,8 +3806,7 @@
           "Jun 2025",
           "May 2025",
           "Apr 2025",
-          "Mar 2025",
-          "Feb 2025"
+          "Mar 2025"
         ]
       }
     ]
@@ -3821,6 +3827,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Aug 2026",
           "Jul 2026",
           "Jun 2026",
           "May 2026",
@@ -3837,8 +3844,7 @@
           "Jun 2025",
           "May 2025",
           "Apr 2025",
-          "Mar 2025",
-          "Feb 2025"
+          "Mar 2025"
         ]
       }
     ]
@@ -3859,6 +3865,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Aug 2026",
           "Jul 2026",
           "Jun 2026",
           "May 2026",
@@ -3875,8 +3882,7 @@
           "Jun 2025",
           "May 2025",
           "Apr 2025",
-          "Mar 2025",
-          "Feb 2025"
+          "Mar 2025"
         ]
       },
       {
@@ -3912,6 +3918,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Aug 2026",
           "Jul 2026",
           "Jun 2026",
           "May 2026",
@@ -3928,8 +3935,7 @@
           "Jun 2025",
           "May 2025",
           "Apr 2025",
-          "Mar 2025",
-          "Feb 2025"
+          "Mar 2025"
         ]
       },
       {
@@ -3937,12 +3943,12 @@
         "description": "The week to show capital contributions for.",
         "type": "String",
         "choices": [
-          "26 Jun, 2026",
-          "19 Jun, 2026",
-          "12 Jun, 2026",
-          "05 Jun, 2026",
-          "29 May, 2026",
-          "22 May, 2026"
+          "07 Aug, 2026",
+          "31 Jul, 2026",
+          "24 Jul, 2026",
+          "17 Jul, 2026",
+          "10 Jul, 2026",
+          "03 Jul, 2026"
         ]
       }
     ]
@@ -3963,12 +3969,12 @@
         "description": "Retrieve data for the specified raid weekend.",
         "type": "String",
         "choices": [
-          "26 Jun, 2026",
-          "19 Jun, 2026",
-          "12 Jun, 2026",
-          "05 Jun, 2026",
-          "29 May, 2026",
-          "22 May, 2026"
+          "07 Aug, 2026",
+          "31 Jul, 2026",
+          "24 Jul, 2026",
+          "17 Jul, 2026",
+          "10 Jul, 2026",
+          "03 Jul, 2026"
         ]
       }
     ]
@@ -3983,6 +3989,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Aug 2026",
           "Jul 2026",
           "Jun 2026",
           "May 2026",
@@ -3999,8 +4006,7 @@
           "Jun 2025",
           "May 2025",
           "Apr 2025",
-          "Mar 2025",
-          "Feb 2025"
+          "Mar 2025"
         ]
       },
       {
@@ -4047,7 +4053,9 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Aug 2026",
           "Jul 2026",
+          "Jun 16, 2026",
           "Jun 2026",
           "May 2026",
           "Apr 2026",
@@ -4057,14 +4065,7 @@
           "Dec 2025",
           "Nov 2025",
           "Oct 2025",
-          "Sep 2025",
-          "Aug 2025",
-          "Jul 2025",
-          "Jun 2025",
-          "May 2025",
-          "Apr 2025",
-          "Mar 2025",
-          "Feb 2025"
+          "Sep 2025"
         ]
       },
       {
@@ -4098,6 +4099,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Aug 2026",
           "Jul 2026",
           "Jun 2026",
           "May 2026",
@@ -4114,8 +4116,7 @@
           "Jun 2025",
           "May 2025",
           "Apr 2025",
-          "Mar 2025",
-          "Feb 2025"
+          "Mar 2025"
         ]
       },
       {
@@ -4166,6 +4167,7 @@
         "description": "Retrieve data since the specified season.",
         "type": "String",
         "choices": [
+          "Since Aug 2026",
           "Since Jul 2026",
           "Since Jun 2026",
           "Since May 2026",
@@ -4182,8 +4184,7 @@
           "Since Jun 2025",
           "Since May 2025",
           "Since Apr 2025",
-          "Since Mar 2025",
-          "Since Feb 2025"
+          "Since Mar 2025"
         ]
       }
     ]
@@ -4223,6 +4224,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Aug 2026",
           "Jul 2026",
           "Jun 2026",
           "May 2026",
@@ -4239,8 +4241,7 @@
           "Jun 2025",
           "May 2025",
           "Apr 2025",
-          "Mar 2025",
-          "Feb 2025"
+          "Mar 2025"
         ]
       }
     ]

--- a/scripts/commands/summary_command.ts
+++ b/scripts/commands/summary_command.ts
@@ -1,6 +1,7 @@
 import { ApplicationCommandOptionType, RESTPostAPIApplicationCommandsJSONBody } from 'discord.js';
 import { command, common } from '../../src/util/locales.js';
 import {
+  getCWLSeasonIds,
   getRaidWeekIds,
   getSeasonIds,
   getSeasonSinceIds,
@@ -110,7 +111,7 @@ export const SUMMARY_COMMAND: RESTPostAPIApplicationCommandsJSONBody = {
           type: ApplicationCommandOptionType.String,
           description: common.options.season.description,
           description_localizations: translation('common.options.season.description'),
-          choices: getSeasonIds()
+          choices: getCWLSeasonIds()
         },
         {
           name: 'clans',

--- a/src/commands/summary/summary-cwl-ranks.ts
+++ b/src/commands/summary/summary-cwl-ranks.ts
@@ -45,18 +45,25 @@ export default class SummaryCWLRanks extends Command {
 
     const chunks = [];
     for (const clan of _clans) {
-      const [lastLeagueGroup, leagueGroup] = await Promise.all([
+      const [{ body, res }, leagueGroup] = await Promise.all([
         this.client.coc.getClanWarLeagueGroup(clan.tag),
         this.client.storage.getWarTags(clan.tag, season)
       ]);
-      if (!leagueGroup?.leagues?.[clan.tag]) continue;
+      const warLeagueId = leagueGroup?.leagues?.[clan.tag];
+      if (!warLeagueId) continue;
 
-      // A specific (past) season is served from the archive; the current one uses live war data.
-      const isApiData = !season;
+      // The requested season is the live one when it matches the API season within a few days (the
+      // CWL season date isn't perfectly predictable); otherwise it's a past/archived season. Prefer
+      // the live body for the current season; on 504/notInWar the live body is unusable, so fall
+      // back to the stored group (a summary spans many clans, so skip-worthy failures can't bail).
+      const isLiveBody = res.ok && body.state !== 'notInWar';
+      const isLiveSeason = !season || Util.estimateCwlSeasonIds(season).includes(body.season);
+      const entityLike = isLiveBody && isLiveSeason ? body : leagueGroup;
+      const isApiData = isLiveSeason;
 
       const aggregated = await this.client.coc.aggregateClanWarLeague(
         clan.tag,
-        leagueGroup,
+        { ...entityLike, leagues: leagueGroup.leagues ?? {} },
         isApiData
       );
       if (!aggregated) continue;
@@ -65,9 +72,9 @@ export default class SummaryCWLRanks extends Command {
       if (!ranking) continue;
 
       chunks.push({
-        warLeagueId: leagueGroup.leagues[clan.tag],
+        warLeagueId,
         ...ranking,
-        status: lastLeagueGroup.body.state
+        status: body.state
       });
     }
 
@@ -197,6 +204,6 @@ export default class SummaryCWLRanks extends Command {
     const pr = new Intl.PluralRules('en-US', { type: 'ordinal' });
     const rule = pr.select(n);
     const suffix = suffixes.get(rule);
-    return `${n}${suffix!}`;
+    return `${n}${suffix}`;
   }
 }


### PR DESCRIPTION
Match the season-resolution pattern used by other CWL commands: prefer the live league group only when the requested season matches the API season (via estimateCwlSeasonIds), and fall back to the stored group when the live body is unusable (504/notInWar). Also switch the season option to CWL season ids.