### PR TITLE
style: reformat to current Prettier settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clashperk",
-  "version": "4.2.93",
+  "version": "4.2.94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clashperk",
-      "version": "4.2.93",
+      "version": "4.2.94",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/cerebras": "^2.0.10",

--- a/src/commands/autorole/nickname-config.ts
+++ b/src/commands/autorole/nickname-config.ts
@@ -323,12 +323,9 @@ export default class NicknameConfigCommand extends Command {
           );
           await modalSubmit.editReply({ withComponents: true, components: [container] });
         } catch (e) {
-          if (
-            !(
-              e instanceof DiscordjsError &&
-              e.code === DiscordjsErrorCodes.InteractionCollectorError
-            )
-          ) {
+          if (!(
+            e instanceof DiscordjsError && e.code === DiscordjsErrorCodes.InteractionCollectorError
+          )) {
             throw e;
           }
         }

--- a/src/commands/link/link-add.ts
+++ b/src/commands/link/link-add.ts
@@ -163,9 +163,9 @@ export default class LinkAddCommand extends Command {
           return this.playerLink(modalSubmit, { player: data, member: interaction.member });
         });
     } catch (e) {
-      if (
-        !(e instanceof DiscordjsError && e.code === DiscordjsErrorCodes.InteractionCollectorError)
-      ) {
+      if (!(
+        e instanceof DiscordjsError && e.code === DiscordjsErrorCodes.InteractionCollectorError
+      )) {
         throw e;
       }
     }

--- a/src/commands/rosters/roster-manage.ts
+++ b/src/commands/rosters/roster-manage.ts
@@ -1626,9 +1626,9 @@ export default class RosterManageCommand extends Command {
           content: messageTexts.join('\n')
         });
       } catch (e) {
-        if (
-          !(e instanceof DiscordjsError && e.code === DiscordjsErrorCodes.InteractionCollectorError)
-        ) {
+        if (!(
+          e instanceof DiscordjsError && e.code === DiscordjsErrorCodes.InteractionCollectorError
+        )) {
           throw e;
         }
       }

--- a/src/commands/search/layout-config.ts
+++ b/src/commands/search/layout-config.ts
@@ -167,12 +167,10 @@ export default class LayoutConfigCommand extends Command {
           const container = getEmbed();
           return interaction.editReply({ components: [container], withComponents: true });
         } catch (error) {
-          if (
-            !(
-              error instanceof DiscordjsError &&
-              error.code === DiscordjsErrorCodes.InteractionCollectorError
-            )
-          ) {
+          if (!(
+            error instanceof DiscordjsError &&
+            error.code === DiscordjsErrorCodes.InteractionCollectorError
+          )) {
             throw error;
           }
         }

--- a/src/commands/search/layout-post.ts
+++ b/src/commands/search/layout-post.ts
@@ -143,12 +143,10 @@ export default class LayoutCommand extends Command {
 
       return await this.handleSubmit(interaction, args);
     } catch (error) {
-      if (
-        !(
-          error instanceof DiscordjsError &&
-          error.code === DiscordjsErrorCodes.InteractionCollectorError
-        )
-      ) {
+      if (!(
+        error instanceof DiscordjsError &&
+        error.code === DiscordjsErrorCodes.InteractionCollectorError
+      )) {
         throw error;
       }
     }
@@ -156,9 +154,7 @@ export default class LayoutCommand extends Command {
 
   public async handleSubmit(
     interaction:
-      | CommandInteraction<'cached'>
-      | ButtonInteraction<'cached'>
-      | ModalSubmitInteraction<'cached'>,
+      CommandInteraction<'cached'> | ButtonInteraction<'cached'> | ModalSubmitInteraction<'cached'>,
     args: LayoutCommandArgs
   ) {
     if (!args.layout_link || !LAYOUT_REGEX.test(args.layout_link)) {
@@ -300,12 +296,10 @@ export default class LayoutCommand extends Command {
 
       return await modalSubmitInteraction.deferUpdate();
     } catch (error) {
-      if (
-        !(
-          error instanceof DiscordjsError &&
-          error.code === DiscordjsErrorCodes.InteractionCollectorError
-        )
-      ) {
+      if (!(
+        error instanceof DiscordjsError &&
+        error.code === DiscordjsErrorCodes.InteractionCollectorError
+      )) {
         throw error;
       }
     }

--- a/src/commands/search/stats.ts
+++ b/src/commands/search/stats.ts
@@ -85,14 +85,12 @@ export default class StatsCommand extends Command {
     const attackerTownHall = Number(match?.groups?.attackerTownHall);
     const defenderTownHall = Number(match?.groups?.defenderTownHall);
 
-    if (
-      !(
-        attackerTownHall > 1 &&
-        attackerTownHall <= MAX_TOWN_HALL_LEVEL &&
-        defenderTownHall > 1 &&
-        defenderTownHall <= MAX_TOWN_HALL_LEVEL
-      )
-    ) {
+    if (!(
+      attackerTownHall > 1 &&
+      attackerTownHall <= MAX_TOWN_HALL_LEVEL &&
+      defenderTownHall > 1 &&
+      defenderTownHall <= MAX_TOWN_HALL_LEVEL
+    )) {
       return 'all';
     }
 

--- a/src/commands/setup/bot-personalizer.ts
+++ b/src/commands/setup/bot-personalizer.ts
@@ -236,12 +236,10 @@ export default class SetupCustomBotCommand extends Command {
         );
         return modalSubmit.editReply(this.reply(messages.join('\n')));
       } catch (error) {
-        if (
-          !(
-            error instanceof DiscordjsError &&
-            error.code === DiscordjsErrorCodes.InteractionCollectorError
-          )
-        ) {
+        if (!(
+          error instanceof DiscordjsError &&
+          error.code === DiscordjsErrorCodes.InteractionCollectorError
+        )) {
           throw error;
         }
       }
@@ -337,12 +335,10 @@ export default class SetupCustomBotCommand extends Command {
           );
         }
       } catch (error) {
-        if (
-          !(
-            error instanceof DiscordjsError &&
-            error.code === DiscordjsErrorCodes.InteractionCollectorError
-          )
-        ) {
+        if (!(
+          error instanceof DiscordjsError &&
+          error.code === DiscordjsErrorCodes.InteractionCollectorError
+        )) {
           throw error;
         }
       }

--- a/src/commands/setup/setup-buttons.ts
+++ b/src/commands/setup/setup-buttons.ts
@@ -268,12 +268,9 @@ export default class SetupButtonsCommand extends Command {
         } catch (e) {
           if (e.code === DiscordErrorCodes.INVALID_FORM_BODY) {
             await resetImages();
-          } else if (
-            !(
-              e instanceof DiscordjsError &&
-              e.code === DiscordjsErrorCodes.InteractionCollectorError
-            )
-          ) {
+          } else if (!(
+            e instanceof DiscordjsError && e.code === DiscordjsErrorCodes.InteractionCollectorError
+          )) {
             throw e;
           }
         }
@@ -435,12 +432,9 @@ export default class SetupButtonsCommand extends Command {
         } catch (e) {
           if (e.code === DiscordErrorCodes.INVALID_FORM_BODY) {
             await resetImages();
-          } else if (
-            !(
-              e instanceof DiscordjsError &&
-              e.code === DiscordjsErrorCodes.InteractionCollectorError
-            )
-          ) {
+          } else if (!(
+            e instanceof DiscordjsError && e.code === DiscordjsErrorCodes.InteractionCollectorError
+          )) {
             throw e;
           }
         }
@@ -597,12 +591,9 @@ export default class SetupButtonsCommand extends Command {
         } catch (e) {
           if (e.code === DiscordErrorCodes.INVALID_FORM_BODY) {
             await resetImages();
-          } else if (
-            !(
-              e instanceof DiscordjsError &&
-              e.code === DiscordjsErrorCodes.InteractionCollectorError
-            )
-          ) {
+          } else if (!(
+            e instanceof DiscordjsError && e.code === DiscordjsErrorCodes.InteractionCollectorError
+          )) {
             throw e;
           }
         }
@@ -759,12 +750,10 @@ export default class SetupButtonsCommand extends Command {
         } catch (error) {
           if (error.code === DiscordErrorCodes.INVALID_FORM_BODY) {
             await resetImages();
-          } else if (
-            !(
-              error instanceof DiscordjsError &&
-              error.code === DiscordjsErrorCodes.InteractionCollectorError
-            )
-          ) {
+          } else if (!(
+            error instanceof DiscordjsError &&
+            error.code === DiscordjsErrorCodes.InteractionCollectorError
+          )) {
             throw error;
           }
         }

--- a/src/commands/setup/setup-clan-embed.ts
+++ b/src/commands/setup/setup-clan-embed.ts
@@ -301,12 +301,10 @@ export default class ClanEmbedCommand extends Command {
 
         await modalSubmit.editReply({ embeds: [embed], components: [buttonRow, menuRow] });
       } catch (error) {
-        if (
-          !(
-            error instanceof DiscordjsError &&
-            error.code === DiscordjsErrorCodes.InteractionCollectorError
-          )
-        ) {
+        if (!(
+          error instanceof DiscordjsError &&
+          error.code === DiscordjsErrorCodes.InteractionCollectorError
+        )) {
           throw error;
         }
       }

--- a/src/commands/setup/setup-events.ts
+++ b/src/commands/setup/setup-events.ts
@@ -362,12 +362,9 @@ export default class SetupEventsCommand extends Command {
             components: [menuRow, durationRow, buttonRow]
           });
         } catch (e) {
-          if (
-            !(
-              e instanceof DiscordjsError &&
-              e.code === DiscordjsErrorCodes.InteractionCollectorError
-            )
-          ) {
+          if (!(
+            e instanceof DiscordjsError && e.code === DiscordjsErrorCodes.InteractionCollectorError
+          )) {
             throw e;
           }
         }
@@ -445,12 +442,9 @@ export default class SetupEventsCommand extends Command {
             components: [menuRow, durationRow, buttonRow]
           });
         } catch (e) {
-          if (
-            !(
-              e instanceof DiscordjsError &&
-              e.code === DiscordjsErrorCodes.InteractionCollectorError
-            )
-          ) {
+          if (!(
+            e instanceof DiscordjsError && e.code === DiscordjsErrorCodes.InteractionCollectorError
+          )) {
             throw e;
           }
         }

--- a/src/commands/setup/setup-server-logs.ts
+++ b/src/commands/setup/setup-server-logs.ts
@@ -472,12 +472,10 @@ export default class SetupUtilsCommand extends Command {
 
         await modalSubmit.editReply(getText());
       } catch (error) {
-        if (
-          !(
-            error instanceof DiscordjsError &&
-            error.code === DiscordjsErrorCodes.InteractionCollectorError
-          )
-        ) {
+        if (!(
+          error instanceof DiscordjsError &&
+          error.code === DiscordjsErrorCodes.InteractionCollectorError
+        )) {
           throw error;
         }
       }

--- a/src/commands/tickets/ticket-close.ts
+++ b/src/commands/tickets/ticket-close.ts
@@ -121,8 +121,7 @@ export default class TicketCloseCommand extends Command {
 
     if (panel?.logChannels.ticketClose) {
       const logCh = interaction.guild!.channels.cache.get(panel.logChannels.ticketClose) as
-        | TextChannel
-        | undefined;
+        TextChannel | undefined;
 
       if (logCh) {
         const logEmbed = new EmbedBuilder()

--- a/src/commands/tickets/ticket-open.ts
+++ b/src/commands/tickets/ticket-open.ts
@@ -923,8 +923,7 @@ export default class TicketOpenCommand extends Command {
     // Log ticket close
     if (panel?.logChannels.ticketClose) {
       const logChannel = interaction.guild!.channels.cache.get(panel.logChannels.ticketClose) as
-        | TextChannel
-        | undefined;
+        TextChannel | undefined;
 
       if (logChannel) {
         const closeContainer = new ContainerBuilder();
@@ -1382,8 +1381,7 @@ export default class TicketOpenCommand extends Command {
     if (!panel.logChannels.buttonClick) return;
 
     const logChannel = interaction.guild!.channels.cache.get(panel.logChannels.buttonClick) as
-      | TextChannel
-      | undefined;
+      TextChannel | undefined;
 
     if (!logChannel) return;
 
@@ -1410,8 +1408,7 @@ export default class TicketOpenCommand extends Command {
 
     const guild = this.client.guilds.cache.get(ticket.guildId);
     const logChannel = guild?.channels.cache.get(panel.logChannels.statusChange) as
-      | TextChannel
-      | undefined;
+      TextChannel | undefined;
 
     if (!logChannel) return;
 

--- a/src/commands/tickets/ticket-reopen.ts
+++ b/src/commands/tickets/ticket-reopen.ts
@@ -45,8 +45,7 @@ export default class TicketReopenCommand extends Command {
     // Move back to open category
     if (btn?.openCategoryId) {
       const openCat = interaction.guild!.channels.cache.get(btn.openCategoryId) as
-        | CategoryChannel
-        | undefined;
+        CategoryChannel | undefined;
 
       if (openCat) {
         await channel.setParent(openCat, { lockPermissions: false }).catch(() => null);
@@ -90,8 +89,7 @@ export default class TicketReopenCommand extends Command {
     // Log
     if (panel?.logChannels.statusChange) {
       const logCh = interaction.guild!.channels.cache.get(panel.logChannels.statusChange) as
-        | TextChannel
-        | undefined;
+        TextChannel | undefined;
 
       if (logCh) {
         await logCh

--- a/src/commands/tickets/ticket-setup.ts
+++ b/src/commands/tickets/ticket-setup.ts
@@ -585,8 +585,7 @@ export default class TicketSetupCommand extends Command {
     });
 
     const displayMode = (submit.fields.getStringSelectValues(customIds.mode)?.[0] ?? 'menu') as
-      | 'menu'
-      | 'buttons';
+      'menu' | 'buttons';
     const label = submit.fields.getTextInputValue(customIds.label) || current.label;
     const emojiRaw = submit.fields.getTextInputValue(customIds.emoji);
     const emoji = emojiRaw && isValidEmoji(emojiRaw) ? emojiRaw : undefined;
@@ -788,8 +787,8 @@ export default class TicketSetupCommand extends Command {
           if (submit) {
             const selected = submit.fields.getStringSelectValues(customIds.select) ?? [];
             if (selected.length === n) {
-              const reordered = selected.map(
-                (id) => currentPanel.ticketTypes.find((t) => t.id === id)!
+              const reordered = selected.map((id) =>
+                currentPanel.ticketTypes.find((t) => t.id === id)!
               );
               await this.ticketPanels.updateOne(
                 { _id: currentPanel._id },
@@ -808,12 +807,10 @@ export default class TicketSetupCommand extends Command {
             );
             for (const b of currentPanel.ticketTypes) getOrCreateButtonIds(b.id);
           } catch (e) {
-            if (
-              !(
-                e instanceof DiscordjsError &&
-                e.code === DiscordjsErrorCodes.InteractionCollectorError
-              )
-            )
+            if (!(
+              e instanceof DiscordjsError &&
+              e.code === DiscordjsErrorCodes.InteractionCollectorError
+            ))
               throw e;
           }
         } else {
@@ -1360,12 +1357,10 @@ export default class TicketSetupCommand extends Command {
             this.client.components.delete(customIds.modal);
           }
         } catch (error) {
-          if (
-            !(
-              error instanceof DiscordjsError &&
-              error.code === DiscordjsErrorCodes.InteractionCollectorError
-            )
-          )
+          if (!(
+            error instanceof DiscordjsError &&
+            error.code === DiscordjsErrorCodes.InteractionCollectorError
+          ))
             throw error;
         }
 
@@ -1707,12 +1702,10 @@ export default class TicketSetupCommand extends Command {
             }
           }
         } catch (error) {
-          if (
-            !(
-              error instanceof DiscordjsError &&
-              error.code === DiscordjsErrorCodes.InteractionCollectorError
-            )
-          )
+          if (!(
+            error instanceof DiscordjsError &&
+            error.code === DiscordjsErrorCodes.InteractionCollectorError
+          ))
             throw error;
         }
 
@@ -2321,12 +2314,10 @@ export default class TicketSetupCommand extends Command {
             }
           }
         } catch (error) {
-          if (
-            !(
-              error instanceof DiscordjsError &&
-              error.code === DiscordjsErrorCodes.InteractionCollectorError
-            )
-          )
+          if (!(
+            error instanceof DiscordjsError &&
+            error.code === DiscordjsErrorCodes.InteractionCollectorError
+          ))
             throw error;
         }
 

--- a/src/commands/tickets/ticket-sleep.ts
+++ b/src/commands/tickets/ticket-sleep.ts
@@ -49,8 +49,7 @@ export default class TicketSleepCommand extends Command {
     // Move to sleep category
     if (btn?.sleepCategoryId) {
       const sleepCat = interaction.guild!.channels.cache.get(btn.sleepCategoryId) as
-        | CategoryChannel
-        | undefined;
+        CategoryChannel | undefined;
 
       if (sleepCat) {
         await channel.setParent(sleepCat, { lockPermissions: false }).catch(() => null);
@@ -65,8 +64,7 @@ export default class TicketSleepCommand extends Command {
     // Log
     if (panel?.logChannels.statusChange) {
       const logCh = interaction.guild!.channels.cache.get(panel.logChannels.statusChange) as
-        | TextChannel
-        | undefined;
+        TextChannel | undefined;
 
       if (logCh) {
         await logCh

--- a/src/commands/util/ask.ts
+++ b/src/commands/util/ask.ts
@@ -26,8 +26,7 @@ export default class AskCommand extends Command {
 
   public async exec(
     interaction:
-      | MessageContextMenuCommandInteraction<'cached'>
-      | ChatInputCommandInteraction<'cached'>,
+      MessageContextMenuCommandInteraction<'cached'> | ChatInputCommandInteraction<'cached'>,
     args: { message: string }
   ) {
     if (!args.message?.length || !(args.message.length >= 5)) {

--- a/src/core/clan-war-log.ts
+++ b/src/core/clan-war-log.ts
@@ -311,9 +311,9 @@ export class ClanWarLog extends RootLog {
                   .toString()
                   .concat('%')
                   .padStart(pad, ' ');
-                return `${stars} \`\u200e${destruction}\` ${BLUE_NUMBERS[attacker.mapPosition]!}${ORANGE_NUMBERS[
-                  attacker.townHallLevel
-                ]!}${EMOJIS.VS}${BLUE_NUMBERS[defender.mapPosition]!}${ORANGE_NUMBERS[defender.townHallLevel]!} ${name}`;
+                return `${stars} \`\u200e${destruction}\` ${BLUE_NUMBERS[attacker.mapPosition]}${
+                  ORANGE_NUMBERS[attacker.townHallLevel]
+                }${EMOJIS.VS}${BLUE_NUMBERS[defender.mapPosition]}${ORANGE_NUMBERS[defender.townHallLevel]} ${name}`;
               })
             ].join('\n')
           }
@@ -539,9 +539,9 @@ export class ClanWarLog extends RootLog {
                 .toString()
                 .concat('%')
                 .padStart(pad, ' ');
-              return `${stars} \`\u200e${destruction}\` ${BLUE_NUMBERS[attacker.mapPosition]}${ORANGE_NUMBERS[
-                attacker.townHallLevel
-              ]!}${EMOJIS.VS}${BLUE_NUMBERS[defender.mapPosition]}${ORANGE_NUMBERS[defender.townHallLevel]} ${name}`;
+              return `${stars} \`\u200e${destruction}\` ${BLUE_NUMBERS[attacker.mapPosition]}${
+                ORANGE_NUMBERS[attacker.townHallLevel]!
+              }${EMOJIS.VS}${BLUE_NUMBERS[defender.mapPosition]}${ORANGE_NUMBERS[defender.townHallLevel]} ${name}`;
             })
           ].join('\n')
         }

--- a/src/listeners/client/message-update.ts
+++ b/src/listeners/client/message-update.ts
@@ -12,12 +12,9 @@ export default class MessageUpdateListener extends Listener {
   }
 
   public async exec(oldMessage: Message, newMessage: Message) {
-    if (
-      !(
-        oldMessage.author?.id === this.client.user.id &&
-        newMessage.author.id === this.client.user.id
-      )
-    )
+    if (!(
+      oldMessage.author?.id === this.client.user.id && newMessage.author.id === this.client.user.id
+    ))
       return;
 
     const oldMessageComponentIds = this.flattenCustomIds(oldMessage);

--- a/src/struct/subscribers.ts
+++ b/src/struct/subscribers.ts
@@ -625,14 +625,7 @@ export interface PatreonMember {
     pledge_relationship_start: string;
     patron_status: 'active_patron' | 'declined_patron' | 'former_patron' | 'account_deleted' | null;
     last_charge_status:
-      | 'Paid'
-      | 'Declined'
-      | 'Deleted'
-      | 'Pending'
-      | 'Refunded'
-      | 'Fraud'
-      | 'Other'
-      | null;
+      'Paid' | 'Declined' | 'Deleted' | 'Pending' | 'Refunded' | 'Fraud' | 'Other' | null;
   };
   id: string;
   relationships: {

--- a/src/struct/ticket-handler.ts
+++ b/src/struct/ticket-handler.ts
@@ -100,8 +100,7 @@ export class TicketHandler {
 
     if (panel?.logChannels.statusChange) {
       const logCh = guild.channels.cache.get(panel.logChannels.statusChange) as
-        | TextChannel
-        | undefined;
+        TextChannel | undefined;
       await logCh
         ?.send({
           embeds: [


### PR DESCRIPTION
Mechanical reflow only — collapses nested negated conditionals, union type annotations, and template literal expressions onto fewer lines. No behavioral changes. Also syncs package-lock.json to 4.2.94.