### PR TITLE
feat(autocomplete): enable clan category autocomplete for export and …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clashperk",
-  "version": "4.2.94",
+  "version": "4.2.95",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clashperk",
-      "version": "4.2.94",
+      "version": "4.2.95",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/cerebras": "^2.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clashperk",
-  "version": "4.2.94",
+  "version": "4.2.95",
   "author": "",
   "license": "MIT",
   "description": "Clash of Clans Discord Bot",

--- a/src/listeners/client/autocomplete-interaction.ts
+++ b/src/listeners/client/autocomplete-interaction.ts
@@ -166,7 +166,7 @@ export default class AutocompleteInteractionListener extends Listener {
         return this.client.autocomplete.startOrEndDateAutocomplete(interaction, focused);
       }
       case 'clans': {
-        if (interaction.commandName === 'activity' && !query) {
+        if (['activity', 'export', 'summary'].includes(interaction.commandName) && !query) {
           return this.client.autocomplete.clanAutoComplete(interaction, {
             withCategory: true,
             isMulti: true


### PR DESCRIPTION
…summary

Extend the empty-query clan autocomplete (multi-select with categories) from `activity` to also cover `export` and `summary`.