### PR TITLE
feat(rosters): allow rosters to display a custom message to users when selecting a group during roster signup

### DIFF
--- a/scripts/commands/roster_command.ts
+++ b/scripts/commands/roster_command.ts
@@ -2,7 +2,7 @@ import { MAX_TOWN_HALL_LEVEL } from '@app/constants';
 import { ApplicationCommandOptionType, RESTPostAPIApplicationCommandsJSONBody } from 'discord.js';
 import { RosterCommandSortOptions, RosterManageActions } from '../../src/util/command.options.js';
 import { command, common } from '../../src/util/locales.js';
-import { channelTypes, translation, guildInstallable } from './@helper.js';
+import { channelTypes, guildInstallable, translation } from './@helper.js';
 
 export const ROSTER_COMMAND: RESTPostAPIApplicationCommandsJSONBody = {
   name: 'roster',
@@ -206,6 +206,14 @@ export const ROSTER_COMMAND: RESTPostAPIApplicationCommandsJSONBody = {
           description: command.roster.create.options.roster_image_url.description,
           description_localizations: translation(
             'command.roster.create.options.roster_image_url.description'
+          ),
+          type: ApplicationCommandOptionType.String
+        },
+        {
+          name: 'custom_category_selection_prompt',
+          description: command.roster.create.options.custom_category_selection_prompt.description,
+          description_localizations: translation(
+            'command.roster.create.options.custom_category_selection_prompt.description'
           ),
           type: ApplicationCommandOptionType.String
         },
@@ -536,6 +544,14 @@ export const ROSTER_COMMAND: RESTPostAPIApplicationCommandsJSONBody = {
           description: command.roster.create.options.roster_image_url.description,
           description_localizations: translation(
             'command.roster.create.options.roster_image_url.description'
+          ),
+          type: ApplicationCommandOptionType.String
+        },
+        {
+          name: 'custom_category_selection_prompt',
+          description: command.roster.create.options.custom_category_selection_prompt.description,
+          description_localizations: translation(
+            'command.roster.create.options.custom_category_selection_prompt.description'
           ),
           type: ApplicationCommandOptionType.String
         },

--- a/scripts/commands/roster_command.ts
+++ b/scripts/commands/roster_command.ts
@@ -2,7 +2,7 @@ import { MAX_TOWN_HALL_LEVEL } from '@app/constants';
 import { ApplicationCommandOptionType, RESTPostAPIApplicationCommandsJSONBody } from 'discord.js';
 import { RosterCommandSortOptions, RosterManageActions } from '../../src/util/command.options.js';
 import { command, common } from '../../src/util/locales.js';
-import { channelTypes, guildInstallable, translation } from './@helper.js';
+import { channelTypes, translation, guildInstallable } from './@helper.js';
 
 export const ROSTER_COMMAND: RESTPostAPIApplicationCommandsJSONBody = {
   name: 'roster',

--- a/src/commands/rosters/roster-create.ts
+++ b/src/commands/rosters/roster-create.ts
@@ -55,6 +55,7 @@ export default class RosterCreateCommand extends Command {
       allow_unlinked?: boolean;
       color_code?: number;
       roster_image_url?: string;
+      custom_category_selection_prompt?: string;
       category?: IRoster['category'];
     }
   ) {
@@ -105,6 +106,7 @@ export default class RosterCreateCommand extends Command {
         args.roster_image_url && URL_REGEX.test(args.roster_image_url)
           ? args.roster_image_url
           : null,
+      customCategorySelectionPrompt: args.custom_category_selection_prompt ?? null,
       roleId: args.roster_role?.id ?? null,
       colorCode: args.color_code ?? defaultSettings.colorCode,
       members: [],

--- a/src/commands/rosters/roster-edit.ts
+++ b/src/commands/rosters/roster-edit.ts
@@ -74,6 +74,7 @@ export default class RosterEditCommand extends Command {
       allow_unlinked?: boolean;
       color_code?: number;
       roster_image_url?: string;
+      custom_category_selection_prompt?: string;
       components_only?: boolean;
       log_channel?: TextChannel | AnyThreadChannel;
       delete_log_channel?: boolean;
@@ -141,6 +142,9 @@ export default class RosterEditCommand extends Command {
     if (args.roster_image_url && URL_REGEX.test(args.roster_image_url))
       data.rosterImage = args.roster_image_url;
     if (args.roster_image_url && /^none$/i.test(args.roster_image_url)) data.rosterImage = null;
+
+    if (args.custom_category_selection_prompt)
+      data.customCategorySelectionPrompt = args.custom_category_selection_prompt;
 
     if (typeof args.allow_multi_signup === 'boolean')
       data.allowMultiSignup = args.allow_multi_signup;

--- a/src/commands/rosters/roster-signup.ts
+++ b/src/commands/rosters/roster-signup.ts
@@ -123,9 +123,11 @@ export default class RosterSignupCommand extends Command {
       category: null
     };
 
+    const categoryMenuPlaceholder =
+      roster.customCategorySelectionPrompt ?? 'Choose a group (confirmed, substitute, etc)';
     const categoryMenu = new StringSelectMenuBuilder()
       .setMinValues(1)
-      .setPlaceholder('Choose a group (confirmed, substitute, etc)')
+      .setPlaceholder(categoryMenuPlaceholder)
       .setCustomId(customIds.category)
       .setOptions(
         selectableCategories.map((category) => ({

--- a/src/struct/roster-manager.ts
+++ b/src/struct/roster-manager.ts
@@ -214,6 +214,7 @@ export interface IRoster {
   logChannelId?: string | null;
   allowCategorySelection?: boolean;
   requireCategorySelection?: boolean;
+  customCategorySelectionPrompt?: string | null;
   lastUpdated: Date;
   createdAt: Date;
 }

--- a/src/util/locales.ts
+++ b/src/util/locales.ts
@@ -478,6 +478,9 @@ export const command = {
         roster_image_url: {
           description: 'Image to be used in the roster embed'
         },
+        custom_category_selection_prompt: {
+          description: 'Custom prompt to show users when selecting a group in the roster'
+        },
         color_code: {
           description: 'Hex color code of the roster embed'
         }


### PR DESCRIPTION
Feature request: https://discord.com/channels/509784317598105619/1484615894041890879

- Adds `custom_category_selection_prompt` option when creating and editing a roster