### PR TITLE
fix: propagate internal API errors instead of swallowing them

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clashperk",
-  "version": "4.2.99",
+  "version": "4.2.100",
   "author": "",
   "license": "MIT",
   "description": "Clash of Clans Discord Bot",

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,12 +1,29 @@
 import { captureException, setContext } from '@sentry/node';
 import { AxiosError } from 'axios';
+import { Agent as HttpAgent } from 'http';
+import { Agent as HttpsAgent } from 'https';
 import { container } from 'tsyringe';
 import { Client } from '../struct/client.js';
 import { Api, HttpClient } from './generated.js';
 
+/** Endpoints that answer with 404 as a normal "no data" result, not as a failure. */
+const EXPECTED_NOT_FOUND = [/^\/legends\/[^/]+\/estimate-rank$/];
+
+const isExpectedError = (error: AxiosError) => {
+  if (error.response?.status !== 404) return false;
+  const url = error.config?.url ?? '';
+  return EXPECTED_NOT_FOUND.some((pattern) => pattern.test(url));
+};
+
+// the host has no IPv6 route, so every AAAA attempt ends in ENETUNREACH before falling back
+const agentOptions = { keepAlive: true, family: 4 } as const;
+
 const httpClient = new HttpClient({
   baseURL: `${process.env.INTERNAL_API_BASE_URL}/v1`,
   secure: true,
+  timeout: 30_000,
+  httpAgent: new HttpAgent(agentOptions),
+  httpsAgent: new HttpsAgent(agentOptions),
   securityWorker: () => {
     return {
       headers: {
@@ -25,17 +42,22 @@ httpClient.instance.interceptors.response.use(
       label: 'AXIOS'
     });
 
-    setContext('http_call_errored', {
-      response: error.response?.data || {},
-      url: error.config?.url,
-      code: error.code,
-      message: error.message,
-      method: error.config?.method,
-      params: error.config?.params,
-      data: error.config?.data
-    });
+    if (!isExpectedError(error)) {
+      setContext('http_call_errored', {
+        response: error.response?.data || {},
+        url: error.config?.url,
+        code: error.code,
+        message: error.message,
+        method: error.config?.method,
+        params: error.config?.params,
+        data: error.config?.data
+      });
 
-    captureException(error);
+      captureException(error);
+    }
+
+    // callers must see the failure; resolving here would hand them an undefined response
+    return Promise.reject(error);
   }
 );
 

--- a/src/commands/export/export-members.ts
+++ b/src/commands/export/export-members.ts
@@ -20,11 +20,15 @@ export default class ExportClanMembersCommand extends Command {
     const { clans } = await this.client.storage.handleSearch(interaction, { args: args.clans });
     if (!clans) return;
 
-    const { data } = await api.exports.exportClanMembers({
-      clanTags: clans.map((clan) => clan.tag),
-      guildId: interaction.guildId,
-      scheduled: !!args.auto_export_on
-    });
+    const { data } = await api.exports.exportClanMembers(
+      {
+        clanTags: clans.map((clan) => clan.tag),
+        guildId: interaction.guildId,
+        scheduled: !!args.auto_export_on
+      },
+      // sheet generation runs long for large guilds; the default client timeout is too tight
+      { timeout: 120_000 }
+    );
 
     return interaction.editReply({
       content: [

--- a/src/commands/export/export-rosters.ts
+++ b/src/commands/export/export-rosters.ts
@@ -48,7 +48,7 @@ export default class RosterExportCommand extends Command {
       rows: roster.members.map((member) => {
         const key = member.categoryId?.toHexString();
         const category = key && key in categoriesMap ? categoriesMap[key].displayName : '';
-        const league = PLAYER_LEAGUE_MAP[member.leagueId.toString()] ?? '';
+        const league = PLAYER_LEAGUE_MAP[member.leagueId?.toString()] ?? '';
         return [
           member.name,
           member.tag,

--- a/src/commands/legend/legend-stats.ts
+++ b/src/commands/legend/legend-stats.ts
@@ -172,7 +172,9 @@ export default class LegendStatsCommand extends Command {
   }
 
   private async getLegendThreshold(isEod: boolean, ref?: string) {
-    const { data } = await api.legends.getLegendRankingThresholds();
+    const result = await api.legends.getLegendRankingThresholds().catch(() => null);
+    if (!result) return null;
+    const { data } = result;
 
     if (ref && moment(ref).isValid()) {
       const entry = data.history.findIndex((record) =>

--- a/src/core/auto-board-log.ts
+++ b/src/core/auto-board-log.ts
@@ -334,8 +334,14 @@ export class AutoBoardLog {
         if (this.queued.has(logId)) continue;
 
         this.queued.add(logId);
-        await this.exec(logId, { channelId: log.channelId });
-        this.queued.delete(logId);
+        try {
+          await this.exec(logId, { channelId: log.channelId });
+        } catch (error: any) {
+          // one failing board must not abort the loop or leave its id queued forever
+          this.client.logger.error(`${error as string} {${logId}}`, { label: 'AutoBoardLog' });
+        } finally {
+          this.queued.delete(logId);
+        }
         await Util.delay(3000);
       }
     } finally {

--- a/src/helper/leaderboard.helper.ts
+++ b/src/helper/leaderboard.helper.ts
@@ -59,12 +59,14 @@ export const getLegendRankingEmbedMaker = async ({
     return record;
   }, {});
 
-  const result = await api.players.getBattleLogLeaderboard({
-    seasonId,
-    playerTags: _players.map(({ tag }) => tag)
-  });
+  const result = await api.players
+    .getBattleLogLeaderboard({
+      seasonId,
+      playerTags: _players.map(({ tag }) => tag)
+    })
+    .catch(() => null);
 
-  let players = (result.data?.items ?? []).map((legend) => {
+  let players = (result?.data?.items ?? []).map((legend) => {
     const player = playersMap[legend.tag];
     return {
       name: player.name,

--- a/src/helper/legends.helper.ts
+++ b/src/helper/legends.helper.ts
@@ -57,7 +57,7 @@ export const getRankedBattleLog = async (
   playerTag: string,
   weekId: string
 ): Promise<BattleLogDto[]> => {
-  const result = await api.players.getBattleLog({ playerTag: encode(playerTag) });
+  const result = await api.players.getBattleLog({ playerTag: encode(playerTag) }).catch(() => null);
   if (!result?.data?.items) return [];
   return result.data.items.filter((b) => b.battleWeek === weekId && b.battleType === 'ranked');
 };
@@ -145,7 +145,9 @@ export const getTournament = async (player: APIPlayer, lastTournament = false) =
 export const getLegendBattleLogAggregate = async (
   playerTag: string
 ): Promise<BattleLogDailyDto[]> => {
-  const result = await api.players.getBattleLogAggregate({ playerTag: encode(playerTag) });
+  const result = await api.players
+    .getBattleLogAggregate({ playerTag: encode(playerTag) })
+    .catch(() => null);
   if (!result?.data?.items) return [];
   return result.data.items;
 };

--- a/src/listeners/handler/error.ts
+++ b/src/listeners/handler/error.ts
@@ -1,4 +1,5 @@
 import { addBreadcrumb, captureException, setContext, setUser } from '@sentry/node';
+import { isAxiosError } from 'axios';
 import {
   ActionRowBuilder,
   AutocompleteInteraction,
@@ -74,13 +75,16 @@ export default class ErrorListener extends Listener {
       id: interaction.user.id,
       username: interaction.user.username
     });
-    captureException(error, {
-      tags: {
-        command: command.id,
-        userId: interaction.user.id,
-        guildId: interaction.guildId || 'DM'
-      }
-    });
+    // the API interceptor already reports these with the full HTTP context
+    if (!isAxiosError(error)) {
+      captureException(error, {
+        tags: {
+          command: command.id,
+          userId: interaction.user.id,
+          guildId: interaction.guildId || 'DM'
+        }
+      });
+    }
 
     const content =
       interaction.inCachedGuild() && !interaction.channel

--- a/src/struct/player-sync.ts
+++ b/src/struct/player-sync.ts
@@ -103,6 +103,7 @@ export class PlayerSync {
         upsert: true
       }
     );
-    await api.players.addPlayerAccount({ playerTag: encode(player.tag) });
+    // background bookkeeping; a failure here must not break the command that triggered it
+    await api.players.addPlayerAccount({ playerTag: encode(player.tag) }).catch(() => null);
   }
 }


### PR DESCRIPTION
## The root cause

The axios response interceptor in `src/api/axios.ts` reported errors to Sentry but never rejected:

```ts
(error: AxiosError<{ message: string }>) => {
  ...
  captureException(error);
}   // ← no return
```

Every failed request therefore **resolved with `undefined`**, and callers crashed on `result.data`. That is [CLASHPERK_BOT-2A2](https://clashperk.sentry.io/issues/CLASHPERK_BOT-2A2) (459 occurrences, 191 users) — an unhandled rejection in the auto-board refresh loop, carrying the same `ETIMEDOUT` HTTP context as [CLASHPERK_BOT-273](https://clashperk.sentry.io/issues/CLASHPERK_BOT-273). The two issues are one failure counted twice.

## Changes

**`src/api/axios.ts`**
- Interceptor now `return Promise.reject(error)`.
- `timeout: 30_000` — a stalled connect previously hung for the full OS TCP timeout (~2 min).
- Keep-alive http/https agents with `family: 4`. Every BOT-273 event shows an immediate `ENETUNREACH` on the Cloudflare AAAA records, so the host has no IPv6 route and each connect was burning a guaranteed-failing attempt first; keep-alive also cuts the TLS reconnects that were timing out.
- `EXPECTED_NOT_FOUND` skips Sentry reporting for `404` on `/legends/{tag}/estimate-rank`. The caller already swallows it by design, but the interceptor reported it anyway — [CLASHPERK_BOT-205](https://clashperk.sentry.io/issues/CLASHPERK_BOT-205), 3,517 events in the last 7 days and the single noisiest issue in the project. Still logged, just not captured.

**`src/listeners/handler/error.ts`** — skips `captureException` for `AxiosError`, since the interceptor now reports those with full HTTP context. Prevents one failure landing in two issues. The user still gets the error reply.

**Call sites**, now that rejections propagate:
- `leaderboard.helper.ts`, `legends.helper.ts` (×2), `legend-stats.ts` — `.catch(() => null)`, preserving each caller's existing empty/null path.
- `player-sync.ts` — `.catch(() => null)`. This runs inside `resolver.updateLastSearchedPlayer`, so an unguarded throw would break every command that resolves a player.
- `export-members.ts` — left to propagate so the user sees the error, with a per-request `timeout: 120_000` since sheet generation for large guilds can exceed the 30s default.

## Two adjacent bugs

- **`export-rosters.ts:51`** — the `?.` that 8e42340d1 added at line 121 but missed at the identical line 51. Fixes [CLASHPERK_BOT-2XS](https://clashperk.sentry.io/issues/CLASHPERK_BOT-2XS).
- **`auto-board-log.ts:337`** — wrapped the per-log `exec` in try/catch/finally. A throw skipped `queued.delete(logId)`, blocking that board from ever refreshing again for the lifetime of the process, and aborted the rest of the cursor loop.

## Verification

`npm run build` and `npm test` (eslint) pass; Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
