### PR TITLE
feat: switch static unit data to clashofclans.js v5 (clash-asset-library)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "ai": "^6.0.33",
         "axios": "^1.19.0",
         "chalk": "^5.6.2",
-        "clashofclans.js": "^4.0.7-dev.299c200",
+        "clashofclans.js": "^5.0.0-dev.12e7625",
         "discord-hybrid-sharding": "^3.0.1",
         "discord.js": "^14.27.0",
         "google-auth-library": "^10.6.2",
@@ -3101,9 +3101,9 @@
       "license": "MIT"
     },
     "node_modules/clashofclans.js": {
-      "version": "4.0.7-dev.299c200",
-      "resolved": "https://registry.npmjs.org/clashofclans.js/-/clashofclans.js-4.0.7-dev.299c200.tgz",
-      "integrity": "sha512-iExCIIfoIQon3Xeokg5fH6Y3woxt52vB5pmYI5U3G9msXk4eSaenx/tJpkpr7n6BRw4lJTpeB8sID0UYR+tzUw==",
+      "version": "5.0.0-dev.12e7625",
+      "resolved": "https://registry.npmjs.org/clashofclans.js/-/clashofclans.js-5.0.0-dev.12e7625.tgz",
+      "integrity": "sha512-YYj032CsZTyowdfbT2aiGqsIi4e2p8cfj8ISGeXocN4kjUNz9ZRIcIrKpp/JQzGDKUmzGlWAlZf8EZZGwirWQA==",
       "license": "MIT",
       "dependencies": {
         "undici": "^7.24.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clashperk",
-  "version": "4.2.100",
+  "version": "4.2.101",
   "author": "",
   "license": "MIT",
   "description": "Clash of Clans Discord Bot",
@@ -44,7 +44,7 @@
     "ai": "^6.0.33",
     "axios": "^1.19.0",
     "chalk": "^5.6.2",
-    "clashofclans.js": "^4.0.7-dev.299c200",
+    "clashofclans.js": "^5.0.0-dev.12e7625",
     "discord-hybrid-sharding": "^3.0.1",
     "discord.js": "^14.27.0",
     "google-auth-library": "^10.6.2",

--- a/src/commands/search/army.ts
+++ b/src/commands/search/army.ts
@@ -27,6 +27,16 @@ const [TOTAL_UNITS, TOTAL_SPELLS] = [340, 11];
 const ARMY_URL_REGEX =
   /^https?:\/\/link\.clashofclans\.com\/[a-z]{1,2}[\/]?\?action=CopyArmy&army=\S+$/;
 
+// Army links carry Supercell's per-category index; static data uses the game's GlobalID.
+const GLOBAL_ID_BASE: Record<string, number> = {
+  troop: 4_000_000,
+  siege: 4_000_000,
+  pet: 73_000_000,
+  spell: 26_000_000,
+  hero: 28_000_000,
+  equipment: 90_000_000
+};
+
 export default class ArmyCommand extends Command {
   public constructor() {
     super('army', {
@@ -195,9 +205,10 @@ export default class ArmyCommand extends Command {
       emojiRecords: Record<string, string>;
     }) => {
       const _findOne = (id: number) => {
+        const globalId = GLOBAL_ID_BASE[subCategory ?? category] + id;
         return RAW_TROOPS.find(
           (en) =>
-            en.id === id &&
+            en.id === globalId &&
             en.category === category &&
             (subCategory ? en.subCategory === subCategory : true) &&
             en.name in emojiRecords
@@ -223,7 +234,8 @@ export default class ArmyCommand extends Command {
     const troops = findUnits({ category: 'troop', emojiRecords: TROOPS, parts: troopList });
     const spells = findUnits({ category: 'spell', emojiRecords: SPELLS, parts: spellList });
     const siegeMachines = findUnits({
-      category: 'siege',
+      category: 'troop',
+      subCategory: 'siege',
       emojiRecords: SIEGE_MACHINES,
       parts: troopList
     });
@@ -232,20 +244,21 @@ export default class ArmyCommand extends Command {
 
     const superTroops = troopList
       .filter((parts) =>
-        RAW_SUPER_TROOPS.find((en) => en.id === parts.id && en.name in SUPER_TROOPS)
+        RAW_SUPER_TROOPS.find(
+          (en) => en.id === GLOBAL_ID_BASE.troop + parts.id && en.name in SUPER_TROOPS
+        )
       )
       .map((parts) => {
-        const unit = RAW_SUPER_TROOPS.find((en) => en.id === parts.id && en.name in SUPER_TROOPS)!;
+        const unit = RAW_SUPER_TROOPS.find(
+          (en) => en.id === GLOBAL_ID_BASE.troop + parts.id && en.name in SUPER_TROOPS
+        )!;
         return {
           id: parts.id,
           total: parts.total,
           name: unit.name,
           category: 'troop',
           subCategory: 'super',
-          hallLevel:
-            RAW_TROOPS.find((en) => en.name === unit.original)!.levels.findIndex(
-              (en) => en >= unit.minOriginalLevel
-            ) + 1,
+          hallLevel: RAW_TROOPS.find((en) => en.id === unit.id)!.unlock.hall,
           housing: unit.housingSpace
         };
       });
@@ -253,12 +266,18 @@ export default class ArmyCommand extends Command {
     const heroes = heroList
       .filter((parts) =>
         RAW_TROOPS.find(
-          (en) => en.id === parts.id && en.category === 'hero' && en.name in HOME_HEROES
+          (en) =>
+            en.id === GLOBAL_ID_BASE.hero + parts.id &&
+            en.category === 'hero' &&
+            en.name in HOME_HEROES
         )
       )
       .map((parts) => {
         const unit = RAW_TROOPS.find(
-          (en) => en.id === parts.id && en.category === 'hero' && en.name in HOME_HEROES
+          (en) =>
+            en.id === GLOBAL_ID_BASE.hero + parts.id &&
+            en.category === 'hero' &&
+            en.name in HOME_HEROES
         )!;
         return {
           id: parts.id,

--- a/src/commands/search/rushed.ts
+++ b/src/commands/search/rushed.ts
@@ -174,7 +174,7 @@ export default class RushedCommand extends Command {
         const hallLevel = unit.village === 'home' ? data.townHallLevel : data.builderHallLevel;
         const { maxLevel, level: _level } = apiTroops.find(
           (u) => u.name === unit.name && u.village === unit.village && u.type === unit.category
-        ) ?? { maxLevel: unit.levels[unit.levels.length - 1], level: 0 };
+        ) ?? { maxLevel: unit.maxLevel, level: 0 };
 
         const level = _level === 0 ? 0 : Math.max(_level, unit.minLevel ?? _level);
 
@@ -184,7 +184,7 @@ export default class RushedCommand extends Command {
           name: unit.name,
           level,
           hallMaxLevel: unit.levels[hallLevel! - 2],
-          maxLevel: Math.max(unit.levels[unit.levels.length - 1], maxLevel)
+          maxLevel: Math.max(unit.maxLevel, maxLevel)
         };
       });
 

--- a/src/commands/search/units.ts
+++ b/src/commands/search/units.ts
@@ -197,7 +197,7 @@ export default class UnitsCommand extends Command {
       const unitsArray = category.units.map((unit) => {
         const { maxLevel, level: _level } = apiTroops.find(
           (u) => u.name === unit.name && u.village === unit.village && u.type === unit.category
-        ) ?? { maxLevel: unit.levels[unit.levels.length - 1], level: 0 };
+        ) ?? { maxLevel: unit.maxLevel, level: 0 };
         const hallLevel = unit.village === 'home' ? data.townHallLevel : data.builderHallLevel;
 
         const level = _level === 0 ? 0 : Math.max(_level, unit.minLevel ?? _level);
@@ -208,7 +208,7 @@ export default class UnitsCommand extends Command {
           name: unit.name,
           level,
           hallMaxLevel: unit.levels[hallLevel! - 1],
-          maxLevel: Math.max(unit.levels[unit.levels.length - 1], maxLevel)
+          maxLevel: Math.max(unit.maxLevel, maxLevel)
         };
       });
 

--- a/src/commands/search/upgrades.ts
+++ b/src/commands/search/upgrades.ts
@@ -138,16 +138,16 @@ export default class UpgradesCommand extends Command {
       );
 
     const getCharacterBuilding = (unit: TroopJSON[string][number]) => {
-      if (unit.allowedCharacters.includes('Barbarian King')) {
+      if (unit.hero === 'Barbarian King') {
         return 'Blacksmith_bk';
       }
-      if (unit.allowedCharacters.includes('Archer Queen')) {
+      if (unit.hero === 'Archer Queen') {
         return 'Blacksmith_aq';
       }
-      if (unit.allowedCharacters.includes('Grand Warden')) {
+      if (unit.hero === 'Grand Warden') {
         return 'Blacksmith_gw';
       }
-      if (unit.allowedCharacters.includes('Royal Champion')) {
+      if (unit.hero === 'Royal Champion') {
         return 'Blacksmith_rc';
       }
       return 'Blacksmith';
@@ -264,7 +264,7 @@ export default class UpgradesCommand extends Command {
         const apiTroop = apiTroops.find(
           (u) => u.name === unit.name && u.village === unit.village && u.type === unit.category
         );
-        const maxLevel = apiTroop?.maxLevel ?? unit.levels[unit.levels.length - 1];
+        const maxLevel = apiTroop?.maxLevel ?? unit.maxLevel;
         const _level = apiTroop?.level ?? 0;
         const hallLevel =
           unit.village === 'home' ? data.townHallLevel : (data.builderHallLevel ?? 0);
@@ -302,7 +302,7 @@ export default class UpgradesCommand extends Command {
           village: unit.village,
           isRushed,
           hallMaxLevel,
-          maxLevel: Math.max(unit.levels[unit.levels.length - 1], maxLevel),
+          maxLevel: Math.max(unit.maxLevel, maxLevel),
           resource: unit.upgrade.resource,
           resources,
           remainingCost,

--- a/src/helper/cache-mapper.helper.ts
+++ b/src/helper/cache-mapper.helper.ts
@@ -401,10 +401,10 @@ const RAW_UNITS_MAP = RAW_DATA.RAW_UNITS.reduce<Record<string, RawUnit>>((record
   record[unit.name] = {
     id: unit.id,
     name: unit.name,
-    village: unit.village as 'home' | 'builderBase',
+    village: unit.village,
     category: unit.category,
     subCategory: unit.subCategory,
-    maxLevel: unit.levels[unit.levels.length - 1]
+    maxLevel: unit.maxLevel
   };
   return record;
 }, {});

--- a/src/util/emojis.ts
+++ b/src/util/emojis.ts
@@ -84,7 +84,9 @@ export const HERO_EQUIPMENT: Record<string, string> = {
   'Stun Blaster': '<:StunBlaster:1483040038789841040>',
   'Rocket Backpack': '<:RocketBackpack:1493662588695740659>',
   'Flame Blower': '<:FlameBlower:1493665431611904221>',
-  'Electro Fangs': '<:ElectroFangs:1498392822158721214>'
+  'Electro Fangs': '<:ElectroFangs:1498392822158721214>',
+  'Monolith Arrow': '<:monolith_arrow:1546061610651615233>',
+  'Revenge Deck': '<:revenge_deck:1546061642830319756>'
 };
 
 export const DARK_ELIXIR_TROOPS: Record<string, string> = {
@@ -99,7 +101,8 @@ export const DARK_ELIXIR_TROOPS: Record<string, string> = {
   'Headhunter': '<:Headhunter:724650414066106459>',
   'Apprentice Warden': '<:ApprenticeWarden:1117866249645461604>',
   'Druid': '<:Druid:1252640516881911900>',
-  'Furnace': '<:Furnace:1354122556499693578>'
+  'Furnace': '<:Furnace:1354122556499693578>',
+  'Ruin Witch': '<:ruin_witch:1546061698471829544>'
 };
 
 export const SIEGE_MACHINES: Record<string, string> = {
@@ -134,7 +137,8 @@ export const DARK_SPELLS: Record<string, string> = {
   'Skeleton Spell': '<:Skeleton:696302204348530698>',
   'Bat Spell': '<:Bat:696303291176583198>',
   'Overgrowth Spell': '<:Overgrowth:1212040817896726631>',
-  'Ice Block Spell': '<:IceBlock:1401438458664452238>'
+  'Ice Block Spell': '<:IceBlock:1401438458664452238>',
+  'Angry Spell': '<:angry_spell:1546061568758784120>'
 };
 
 export const SUPER_TROOPS: Record<string, string> = {

--- a/src/util/troops.ts
+++ b/src/util/troops.ts
@@ -1,4 +1,4 @@
-import { RAW_DATA } from 'clashofclans.js';
+import { RAW_DATA, RawUnit } from 'clashofclans.js';
 import { ALL_TROOPS, SUPER_TROOPS } from './emojis.js';
 
 export const RAW_TROOPS = RAW_DATA.RAW_UNITS;
@@ -97,30 +97,5 @@ export const ARMY_CAPACITY = [
   }
 ];
 
-export interface TroopJSON {
-  [key: string]: {
-    id: number;
-    name: string;
-    village: string;
-    category: string;
-    subCategory: string;
-    unlock: {
-      hall: number;
-      cost: number;
-      time: number;
-      resource: string;
-      building: string;
-      buildingLevel: number;
-    };
-    upgrade: {
-      cost: number[];
-      time: number[];
-      resource: string;
-      resources: { resource: string; cost: number }[][];
-    };
-    allowedCharacters: string[];
-    minLevel?: number | null;
-    seasonal: boolean;
-    levels: number[];
-  }[];
-}
+/** Units grouped by the building that unlocks them. */
+export type TroopJSON = Record<string, RawUnit[]>;


### PR DESCRIPTION
## Summary

Bumps `clashofclans.js` to `5.0.0-dev.12e7625` ([clashperk/clashofclans.js#253](https://github.com/clashperk/clashofclans.js/pull/253)), which sources `RAW_UNITS` / `RAW_SUPER_UNITS` from [clash-asset-library](https://github.com/clashperk/clash-asset-library)'s `units.json` instead of the hand-maintained `raw.json`, and adapts the bot to the new model.

- **army**: army-link ids are Supercell's per-category index while unit ids are now GlobalIDs, so lookups go through a `GLOBAL_ID_BASE` map. Also fixes the siege-machine lookup, which passed `category: 'siege'` (units are `category: 'troop'`, `subCategory: 'siege'`) and therefore never matched.
- **upgrades**: equipment grouping uses `unit.hero` (was `allowedCharacters[]`).
- **units / rushed / upgrades / cache-mapper**: max level comes from `unit.maxLevel` instead of the last entry of the per-hall `levels` array — builder-base arrays are now correctly 10 entries (BH1–10), so the old idiom would have shown 16 instead of 20 for e.g. Raged Barbarian.
- **troops**: `TroopJSON` is `Record<string, RawUnit[]>` from the lib; the duplicated interface is gone.
- **emojis**: adds the four units present in the new data but missing here — Ruin Witch, Angry Spell, Monolith Arrow, Revenge Deck. Every non-seasonal unit in the data now has an emoji.

## Behavior changes to expect

- Heroes render in in-game order (BK, AQ, Minion Prince, GW, RC, Dragon Duke); pets by Pet House level.
- Barbarian King is unlocked at TH4 (Hero Hall 1) per the new data; hero max levels 110/110/85.
- Super troops require TH11 in the static data itself (previously only enforced by call sites).

Everything else (per-TH max levels, unlock buildings, upgrade/ore costs) was verified identical to the old `raw.json` for all 147 legacy units.

## Test plan

- [x] `tsc --noEmit` and `npm test` (eslint) pass against the published dev package
- [x] Runtime smoke: `getRawUnit`, `RAW_SUPER_UNITS`, equipment ore costs, new units resolve
- [ ] Spot-check `/units`, `/upgrades`, `/rushed`, `/army` (incl. a link with siege machines and a super troop) on a test server

🤖 Generated with [Claude Code](https://claude.com/claude-code)
