### PR TITLE
fix: disable detach_clan option to stay within 25-option limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clashperk",
-  "version": "4.2.99",
+  "version": "4.2.101",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clashperk",
-      "version": "4.2.99",
+      "version": "4.2.101",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/cerebras": "^2.0.10",

--- a/scripts/assets/commands_export.json
+++ b/scripts/assets/commands_export.json
@@ -127,6 +127,7 @@
         "description": "The season to show attacks for.",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 2026",
@@ -143,8 +144,7 @@
           "Jul 2025",
           "Jun 2025",
           "May 2025",
-          "Apr 2025",
-          "Mar 2025"
+          "Apr 2025"
         ]
       }
     ]
@@ -930,12 +930,12 @@
         "description": "The week to show contributions for.",
         "type": "String",
         "choices": [
+          "04 Sep, 2026",
+          "28 Aug, 2026",
+          "21 Aug, 2026",
+          "14 Aug, 2026",
           "07 Aug, 2026",
-          "31 Jul, 2026",
-          "24 Jul, 2026",
-          "17 Jul, 2026",
-          "10 Jul, 2026",
-          "03 Jul, 2026"
+          "31 Jul, 2026"
         ]
       }
     ]
@@ -962,12 +962,12 @@
         "description": "Retrieve data for the specified raid weekend.",
         "type": "String",
         "choices": [
+          "04 Sep, 2026",
+          "28 Aug, 2026",
+          "21 Aug, 2026",
+          "14 Aug, 2026",
           "07 Aug, 2026",
-          "31 Jul, 2026",
-          "24 Jul, 2026",
-          "17 Jul, 2026",
-          "10 Jul, 2026",
-          "03 Jul, 2026"
+          "31 Jul, 2026"
         ]
       }
     ]
@@ -1070,6 +1070,7 @@
         "description": "The season to show the scoreboard for.",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 2026",
@@ -1086,8 +1087,7 @@
           "Jul 2025",
           "Jun 2025",
           "May 2025",
-          "Apr 2025",
-          "Mar 2025"
+          "Apr 2025"
         ]
       }
     ]
@@ -1183,6 +1183,7 @@
         "description": "CWL season",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 16, 2026",
@@ -1194,8 +1195,7 @@
           "Jan 2026",
           "Dec 2025",
           "Nov 2025",
-          "Oct 2025",
-          "Sep 2025"
+          "Oct 2025"
         ]
       },
       {
@@ -1279,6 +1279,7 @@
         "description": "CWL season",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 16, 2026",
@@ -1290,8 +1291,7 @@
           "Jan 2026",
           "Dec 2025",
           "Nov 2025",
-          "Oct 2025",
-          "Sep 2025"
+          "Oct 2025"
         ]
       },
       {
@@ -1318,6 +1318,7 @@
         "description": "CWL season",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 16, 2026",
@@ -1329,8 +1330,7 @@
           "Jan 2026",
           "Dec 2025",
           "Nov 2025",
-          "Oct 2025",
-          "Sep 2025"
+          "Oct 2025"
         ]
       },
       {
@@ -1357,6 +1357,7 @@
         "description": "CWL season",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 16, 2026",
@@ -1368,8 +1369,7 @@
           "Jan 2026",
           "Dec 2025",
           "Nov 2025",
-          "Oct 2025",
-          "Sep 2025"
+          "Oct 2025"
         ]
       },
       {
@@ -1408,6 +1408,7 @@
         "description": "The season to show donations for.",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 2026",
@@ -1424,8 +1425,7 @@
           "Jul 2025",
           "Jun 2025",
           "May 2025",
-          "Apr 2025",
-          "Mar 2025"
+          "Apr 2025"
         ]
       },
       {
@@ -1556,6 +1556,7 @@
         "description": "Retrieve data since the specified season.",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 16, 2026",
@@ -1567,8 +1568,7 @@
           "Jan 2026",
           "Dec 2025",
           "Nov 2025",
-          "Oct 2025",
-          "Sep 2025"
+          "Oct 2025"
         ]
       },
       {
@@ -1604,6 +1604,7 @@
         "description": "Retrieve data since the specified season.",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 2026",
@@ -1620,8 +1621,7 @@
           "Jul 2025",
           "Jun 2025",
           "May 2025",
-          "Apr 2025",
-          "Mar 2025"
+          "Apr 2025"
         ]
       },
       {
@@ -1678,6 +1678,7 @@
         "description": "Retrieve data since the specified season.",
         "type": "String",
         "choices": [
+          "Since Sep 2026",
           "Since Aug 2026",
           "Since Jul 2026",
           "Since Jun 2026",
@@ -1694,8 +1695,7 @@
           "Since Jul 2025",
           "Since Jun 2025",
           "Since May 2025",
-          "Since Apr 2025",
-          "Since Mar 2025"
+          "Since Apr 2025"
         ]
       },
       {
@@ -1739,6 +1739,7 @@
         "description": "Retrieve data since the specified season.",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 2026",
@@ -1755,8 +1756,7 @@
           "Jul 2025",
           "Jun 2025",
           "May 2025",
-          "Apr 2025",
-          "Mar 2025"
+          "Apr 2025"
         ]
       },
       {
@@ -2082,6 +2082,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 2026",
@@ -2098,8 +2099,7 @@
           "Jul 2025",
           "Jun 2025",
           "May 2025",
-          "Apr 2025",
-          "Mar 2025"
+          "Apr 2025"
         ]
       }
     ]
@@ -2120,6 +2120,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 2026",
@@ -2136,8 +2137,7 @@
           "Jul 2025",
           "Jun 2025",
           "May 2025",
-          "Apr 2025",
-          "Mar 2025"
+          "Apr 2025"
         ]
       }
     ]
@@ -2158,6 +2158,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 2026",
@@ -2174,8 +2175,7 @@
           "Jul 2025",
           "Jun 2025",
           "May 2025",
-          "Apr 2025",
-          "Mar 2025"
+          "Apr 2025"
         ]
       }
     ]
@@ -2252,6 +2252,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 2026",
@@ -2268,8 +2269,7 @@
           "Jul 2025",
           "Jun 2025",
           "May 2025",
-          "Apr 2025",
-          "Mar 2025"
+          "Apr 2025"
         ]
       },
       {
@@ -2878,6 +2878,18 @@
         "choices": []
       },
       {
+        "name": "require_group_selection",
+        "description": "Whether to require members to select group",
+        "type": "Boolean",
+        "choices": []
+      },
+      {
+        "name": "group_selection_text",
+        "description": "Custom text shown to members when they select a roster group",
+        "type": "String",
+        "choices": []
+      },
+      {
         "name": "allow_multi_signup",
         "description": "Whether to allow multiple roster signups",
         "type": "Boolean",
@@ -2948,12 +2960,6 @@
         "name": "clan",
         "description": "Clan of the roster",
         "type": "String",
-        "choices": []
-      },
-      {
-        "name": "detach_clan",
-        "description": "Detach clan from the roster",
-        "type": "Boolean",
         "choices": []
       },
       {
@@ -3043,6 +3049,18 @@
         "name": "allow_group_selection",
         "description": "Whether to allow members to select group",
         "type": "Boolean",
+        "choices": []
+      },
+      {
+        "name": "require_group_selection",
+        "description": "Whether to require members to select group",
+        "type": "Boolean",
+        "choices": []
+      },
+      {
+        "name": "group_selection_text",
+        "description": "Custom text shown to members when they select a roster group",
+        "type": "String",
         "choices": []
       },
       {
@@ -3610,6 +3628,7 @@
         "description": "Retrieve data since the specified season.",
         "type": "String",
         "choices": [
+          "Since Sep 2026",
           "Since Aug 2026",
           "Since Jul 2026",
           "Since Jun 2026",
@@ -3626,8 +3645,7 @@
           "Since Jul 2025",
           "Since Jun 2025",
           "Since May 2025",
-          "Since Apr 2025",
-          "Since Mar 2025"
+          "Since Apr 2025"
         ]
       },
       {
@@ -3730,6 +3748,7 @@
         "description": "Retrieve data since the specified season.",
         "type": "String",
         "choices": [
+          "Since Sep 2026",
           "Since Aug 2026",
           "Since Jul 2026",
           "Since Jun 2026",
@@ -3746,8 +3765,7 @@
           "Since Jul 2025",
           "Since Jun 2025",
           "Since May 2025",
-          "Since Apr 2025",
-          "Since Mar 2025"
+          "Since Apr 2025"
         ]
       },
       {
@@ -3789,6 +3807,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 2026",
@@ -3805,8 +3824,7 @@
           "Jul 2025",
           "Jun 2025",
           "May 2025",
-          "Apr 2025",
-          "Mar 2025"
+          "Apr 2025"
         ]
       }
     ]
@@ -3827,6 +3845,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 2026",
@@ -3843,8 +3862,7 @@
           "Jul 2025",
           "Jun 2025",
           "May 2025",
-          "Apr 2025",
-          "Mar 2025"
+          "Apr 2025"
         ]
       }
     ]
@@ -3865,6 +3883,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 2026",
@@ -3881,8 +3900,7 @@
           "Jul 2025",
           "Jun 2025",
           "May 2025",
-          "Apr 2025",
-          "Mar 2025"
+          "Apr 2025"
         ]
       },
       {
@@ -3918,6 +3936,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 2026",
@@ -3934,8 +3953,7 @@
           "Jul 2025",
           "Jun 2025",
           "May 2025",
-          "Apr 2025",
-          "Mar 2025"
+          "Apr 2025"
         ]
       },
       {
@@ -3943,12 +3961,12 @@
         "description": "The week to show capital contributions for.",
         "type": "String",
         "choices": [
+          "04 Sep, 2026",
+          "28 Aug, 2026",
+          "21 Aug, 2026",
+          "14 Aug, 2026",
           "07 Aug, 2026",
-          "31 Jul, 2026",
-          "24 Jul, 2026",
-          "17 Jul, 2026",
-          "10 Jul, 2026",
-          "03 Jul, 2026"
+          "31 Jul, 2026"
         ]
       }
     ]
@@ -3969,12 +3987,12 @@
         "description": "Retrieve data for the specified raid weekend.",
         "type": "String",
         "choices": [
+          "04 Sep, 2026",
+          "28 Aug, 2026",
+          "21 Aug, 2026",
+          "14 Aug, 2026",
           "07 Aug, 2026",
-          "31 Jul, 2026",
-          "24 Jul, 2026",
-          "17 Jul, 2026",
-          "10 Jul, 2026",
-          "03 Jul, 2026"
+          "31 Jul, 2026"
         ]
       }
     ]
@@ -3989,6 +4007,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 2026",
@@ -4005,8 +4024,7 @@
           "Jul 2025",
           "Jun 2025",
           "May 2025",
-          "Apr 2025",
-          "Mar 2025"
+          "Apr 2025"
         ]
       },
       {
@@ -4053,6 +4071,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 16, 2026",
@@ -4064,8 +4083,7 @@
           "Jan 2026",
           "Dec 2025",
           "Nov 2025",
-          "Oct 2025",
-          "Sep 2025"
+          "Oct 2025"
         ]
       },
       {
@@ -4099,6 +4117,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 2026",
@@ -4115,8 +4134,7 @@
           "Jul 2025",
           "Jun 2025",
           "May 2025",
-          "Apr 2025",
-          "Mar 2025"
+          "Apr 2025"
         ]
       },
       {
@@ -4167,6 +4185,7 @@
         "description": "Retrieve data since the specified season.",
         "type": "String",
         "choices": [
+          "Since Sep 2026",
           "Since Aug 2026",
           "Since Jul 2026",
           "Since Jun 2026",
@@ -4183,8 +4202,7 @@
           "Since Jul 2025",
           "Since Jun 2025",
           "Since May 2025",
-          "Since Apr 2025",
-          "Since Mar 2025"
+          "Since Apr 2025"
         ]
       }
     ]
@@ -4224,6 +4242,7 @@
         "description": "Retrieve data for the specified season.",
         "type": "String",
         "choices": [
+          "Sep 2026",
           "Aug 2026",
           "Jul 2026",
           "Jun 2026",
@@ -4240,8 +4259,7 @@
           "Jul 2025",
           "Jun 2025",
           "May 2025",
-          "Apr 2025",
-          "Mar 2025"
+          "Apr 2025"
         ]
       }
     ]

--- a/scripts/assets/troops_export.json
+++ b/scripts/assets/troops_export.json
@@ -82,7 +82,9 @@
     "Stun Blaster",
     "Rocket Backpack",
     "Flame Blower",
-    "Electro Fangs"
+    "Electro Fangs",
+    "Monolith Arrow",
+    "Revenge Deck"
   ],
   "DARK_ELIXIR_TROOPS": [
     "Minion",
@@ -96,7 +98,8 @@
     "Headhunter",
     "Apprentice Warden",
     "Druid",
-    "Furnace"
+    "Furnace",
+    "Ruin Witch"
   ],
   "SIEGE_MACHINES": [
     "Wall Wrecker",
@@ -128,7 +131,8 @@
     "Skeleton Spell",
     "Bat Spell",
     "Overgrowth Spell",
-    "Ice Block Spell"
+    "Ice Block Spell",
+    "Angry Spell"
   ],
   "SUPER_TROOPS": [
     "Super Barbarian",
@@ -214,6 +218,7 @@
     "Apprentice Warden",
     "Druid",
     "Furnace",
+    "Ruin Witch",
     "Wall Wrecker",
     "Battle Blimp",
     "Stone Slammer",
@@ -240,6 +245,7 @@
     "Bat Spell",
     "Overgrowth Spell",
     "Ice Block Spell",
+    "Angry Spell",
     "L.A.S.S.I",
     "Electro Owl",
     "Mighty Yak",
@@ -291,7 +297,9 @@
     "Stun Blaster",
     "Rocket Backpack",
     "Flame Blower",
-    "Electro Fangs"
+    "Electro Fangs",
+    "Monolith Arrow",
+    "Revenge Deck"
   ],
   "BUILDER_TROOPS": [
     "Raged Barbarian",

--- a/scripts/commands/roster_command.ts
+++ b/scripts/commands/roster_command.ts
@@ -393,14 +393,14 @@ export const ROSTER_COMMAND: RESTPostAPIApplicationCommandsJSONBody = {
           autocomplete: true,
           type: ApplicationCommandOptionType.String
         },
-        {
-          name: 'detach_clan',
-          description: command.roster.edit.options.detach_clan.description,
-          description_localizations: translation(
-            'command.roster.edit.options.detach_clan.description'
-          ),
-          type: ApplicationCommandOptionType.Boolean
-        },
+        // {
+        //   name: 'detach_clan',
+        //   description: command.roster.edit.options.detach_clan.description,
+        //   description_localizations: translation(
+        //     'command.roster.edit.options.detach_clan.description'
+        //   ),
+        //   type: ApplicationCommandOptionType.Boolean
+        // },
         {
           name: 'allow_unlinked',
           description: command.roster.create.options.allow_unlinked.description,

--- a/scripts/update_commands_script.ts
+++ b/scripts/update_commands_script.ts
@@ -50,6 +50,10 @@ function commandStructureValidationCheck(obj: Record<string, any>) {
   if (obj.options) {
     obj.options.map(commandStructureValidationCheck);
   }
+
+  if (obj.options?.length > 25) {
+    console.log(obj);
+  }
 }
 
 async function exportCommands(commands: ApplicationCommand[]) {


### PR DESCRIPTION
## Summary
- Comment out the `detach_clan` option on `/roster edit` because the subcommand exceeded Discord's 25-option limit (the handler in `src/commands/rosters/roster-edit.ts` still supports it if re-enabled later)
- Log any command whose options exceed 25 in `scripts/update_commands_script.ts` so this is caught before deploy
- Regenerate `commands_export.json` (Sep 2026 season / raid weekend choices) and `troops_export.json` (Monolith Arrow, Revenge Deck, Ruin Witch, Angry Spell)
- Sync `package-lock.json` version to 4.2.101

## Test plan
- [ ] `npm test` passes
- [ ] `npm run deploy` succeeds without a 25-option validation error for `/roster edit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)